### PR TITLE
Typos and cross-platform fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,23 +13,34 @@ lib_src    = $(wildcard src/libmontre/*.cpp)
 
 dist_files = $(lib_hdr) $(lib_src)
 
-LIBEXT    = .so
+# platform-specific setup
+LIBEXT    = $(shell pkg-config pure --variable DLL)
+PIC       = $(shell pkg-config pure --variable PIC)
+shared    = $(shell pkg-config pure --variable shared)
+
+ifeq ($(LIBEXT),.dylib)
+LDPATH = DYLD_LIBRARY_PATH
+else
+LDPATH = LD_LIBRARY_PATH
+endif
 
 .PHONY: all clean install uninstall
 
 all: $(PACKAGE)
 
 $(PACKAGE): $(patsubst %.cpp, %.o, $(lib_src))
-	$(CXX) -shared -fPIC $(CXXFLAGS) $(LDFLAGS) $^ $(lib_libs) -o $(LIBPACKAGE)$(LIBEXT)
-	pure -c src/main.pure -o $(PACKAGE)
+	$(CXX) $(shared) $(PIC) $(soname) $(CXXFLAGS) $(LDFLAGS) $^ $(lib_libs) -o $(LIBPACKAGE)$(LIBEXT)
+# We need to set LD_LIBRARY_PATH here so that the library is found without
+# hard-coding its path into the executable.
+	$(LDPATH)=. pure -c src/main.pure -o $(PACKAGE)
 
 clean:
 	rm -f src/libmontre/*.o src/libmontre/*.d $(PACKAGE) $(LIBPACKAGE)$(LIBEXT)
 
 install: $(PACKAGE)
-	mkdir -p $(prefix)/lib
+	mkdir -p $(PREFIX)/lib
 	cp $(LIBPACKAGE)$(LIBEXT) $(PREFIX)/lib
-	mkdir -p $(prefix)/bin
+	mkdir -p $(PREFIX)/bin
 	cp $(PACKAGE) $(PREFIX)/bin
 
 uninstall:


### PR DESCRIPTION
Fixed `$(prefix)` in the Makefile (must be `$(PREFIX)`), and use `pkg-config pure` to improve cross-platform compatibility. Also, `LD_LIBRARY_PATH` must be used in the batch compilation so that the uninstalled libmontre is found without hard-coding the path into the `montre` executable.

This builds and installs fine on both Linux and OSX now (Windows should most likely work as well, but I haven't tested it). But note that this still requires that libmontre gets installed in a place where the dynamic linker can find it. There are ways to make this work if the library is not on the default search path (e.g., the library could be installed in the Pure library folder), but maybe it's good enough to just add a note to the README that the user should pick PREFIX accordingly, or make sure that $(PREFIX)/lib is on the dynamic library search path.
